### PR TITLE
Remove outdated `owner` attribute (not used)

### DIFF
--- a/s3backup/backups.py
+++ b/s3backup/backups.py
@@ -320,7 +320,6 @@ class BucketObject(object):
 
         Note the _initialized... This makes this object immutable.
         """
-        self.owner = contents["Owner"]["DisplayName"]
         self.modified = contents["LastModified"]
         self.filename = contents["Key"]
         self.etag = contents["ETag"]
@@ -332,7 +331,6 @@ class BucketObject(object):
         adict = {
             'modified': self.modified,
             'filename': self.filename,
-            'owner': self.owner,
             'size': self.size,
             'etag': self.etag
         }


### PR DESCRIPTION
# Description
The S3 backups which contain the built versions of the backends for the `staging-*` and `production` environments are not uploading. This is due to a KeyError with the S3Backup package, which appears to be looking for an `"Owner"` tag on objects which do not have this.

# Resolution
As no such `"Owner"` tag exists, and there are no apparent uses of it, this reference was simply removed.

# Additional Changes
A [backend](https://github.com/CobaltLP/backend) Jenkinsfile change to point `staging` and `master` to this new Git repo will have to be made (we currently still point to Bison's copy).